### PR TITLE
fix UI deadlocks + improve visual word colors

### DIFF
--- a/wordle/user_interface.go
+++ b/wordle/user_interface.go
@@ -2,7 +2,7 @@ package wordle
 
 import (
 	"context"
-	"fmt"
+	"time"
 
 	"github.com/p2p-games/wordle/model"
 )
@@ -21,7 +21,8 @@ type WordleUI struct {
 
 	CannonicalHeader *model.Header
 
-	tm *TerminalManager
+	uiInitialized bool
+	tm            *TerminalManager
 }
 
 func NewWordleUI(ctx context.Context, wordleServ *Service, peerId string) *WordleUI {
@@ -33,6 +34,10 @@ func NewWordleUI(ctx context.Context, wordleServ *Service, peerId string) *Wordl
 	}
 
 	wordleServ.SetLog(func(s string) {
+		// wait untill UI is initialilzed
+		for !ui.uiInitialized {
+			time.Sleep(200 * time.Millisecond)
+		}
 		ui.AddDebugItem(s)
 	})
 
@@ -48,43 +53,69 @@ func (w *WordleUI) Run() {
 		panic("non able to load any header from the datastore, not even genesis??!")
 	}
 
-	// generate a new game
-	w.CurrentGame = NewWordGame(w.ctx, w.PeerId, w.CannonicalHeader.PeerID, w.CannonicalHeader.Proposal, w.WordleServ)
+	// generate a guess channel
+	userGuessC := make(chan guess)
 
-	// generate a terminal manager
-	w.tm = NewTerminalManager(w.ctx, w.CurrentGame)
-	err = w.tm.Run()
-	if err != nil {
-		panic(err)
-	}
+	// generate a new game
+	w.CurrentGame = NewWordGame(w.PeerId, w.CannonicalHeader.PeerID, w.CannonicalHeader.Proposal, userGuessC)
+
 	// get the channel for incoming headers
 	incomingHeaders, err := w.WordleServ.Guesses(w.ctx)
 	if err != nil {
 		panic("unable to retrieve the channel of headers from the user interface")
 	}
+	go func() {
+		for {
+			select {
+			case userGuess := <-userGuessC:
+				w.tm.AddDebugMsg("about to send new guess")
+				// notify the service of a new User Guess
+				err = w.WordleServ.Guess(w.ctx, userGuess.Guess, userGuess.Proposal)
+				if err != nil {
+					w.tm.AddDebugMsg("error sending guess" + userGuess.Guess + " - " + err.Error())
+				}
 
-	for {
-		select {
-		case recHeader := <-incomingHeaders: // incoming New Message from surrounding peers
-			w.AddDebugItem(fmt.Sprintf("guess received from %s", recHeader.PeerID))
-			// verify weather the header is correct or not
-			if model.Verify(recHeader.Guess, w.CannonicalHeader.Proposal) {
-				w.CannonicalHeader = recHeader
-				// generate a new one game
-				w.CurrentGame = NewWordGame(w.ctx, w.PeerId, w.CannonicalHeader.PeerID, recHeader.Proposal, w.WordleServ)
+				// check if the guess if the guess was right for debug-msg purpose
+				bools, err := model.VerifyString(userGuess.Guess, w.CannonicalHeader.Proposal)
+				if err != nil {
+					w.tm.AddDebugMsg("error verifying the guess" + err.Error())
+				}
 
-				// refresh the terminal manager
-				w.tm.Game = w.CurrentGame
-			} else {
-				// Actually, there isn't anything else to do
-				continue
+				if IsGuessSuccess(bools) {
+					w.tm.AddDebugMsg("succ guess sent")
+				} else {
+					w.tm.AddDebugMsg("wrong guess sent")
+				}
+
+			case recHeader := <-incomingHeaders: // incoming New Message from surrounding peers
+				//w.AddDebugItem(fmt.Sprintf("guess received from %s", recHeader.PeerID))
+				// verify weather the header is correct or not
+				if model.Verify(recHeader.Guess, w.CannonicalHeader.Proposal) {
+					w.CannonicalHeader = recHeader
+					// generate a new one game
+
+					w.CurrentGame = NewWordGame(w.PeerId, w.CannonicalHeader.PeerID, recHeader.Proposal, userGuessC)
+					// refresh the terminal manager
+					w.tm.Game = w.CurrentGame
+				}
+			case <-w.ctx.Done(): // context shutdow
+				return
 			}
-		case <-w.ctx.Done(): // context shutdow
-			return
+
+			// render the new state of the UI
+			w.tm.RefreshWordleState()
 		}
+	}()
+
+	// generate a terminal manager
+	w.tm = NewTerminalManager(w.ctx, w.CurrentGame)
+	err = w.tm.Run(&w.uiInitialized)
+	if err != nil {
+		panic(err)
 	}
+
 }
 
 func (w *WordleUI) AddDebugItem(s string) {
-	w.tm.AddDebugItem(s)
+	w.tm.AddDebugMsg(s)
 }

--- a/wordle/utils.go
+++ b/wordle/utils.go
@@ -85,7 +85,7 @@ func ComposeWordleVisualWord(word string, target *model.Word) string {
 
 		switch charStatus {
 		case 0: // not in the word
-			compWord += composeCharWithColor(c[i], "")
+			compWord += composeCharWithColor(c[i], "white")
 		case 1: // in the word but on wrong possition
 			compWord += composeCharWithColor(c[i], Yellow)
 		case 2: // bingo
@@ -93,7 +93,7 @@ func ComposeWordleVisualWord(word string, target *model.Word) string {
 		}
 
 	}
-	return compWord
+	return compWord + "[white]"
 }
 
 // compose the character over the color and reset the terminal color

--- a/wordle/word_game_test.go
+++ b/wordle/word_game_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestStateTransition(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-
+	defer cancel()
 	require := require.New(t)
 	salts := []string{"a", "b", "c", "d", "e"}
 	target := &model.Word{
@@ -43,7 +43,8 @@ func TestStateTransition(t *testing.T) {
 	go func() {
 		for {
 			select {
-			case _ = <-guessMsgC:
+			case guess := <-guessMsgC:
+				t.Log("guess msg received, guess:" + guess.Guess + " | proposal:" + guess.Proposal)
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
Fixed problem with the `terminal manager` (tview) that was freezing the entire UI.

Added a flag that restricts printing debug messages in the console until the UI is initialized.

NOTE: We can play alone even if we don't have any peers connected, we should take a look at it (the user can achieve a longer word count by playing in localhost and then connecting to the network)